### PR TITLE
Add DESK_SHELL_ARGS variable

### DIFF
--- a/desk
+++ b/desk
@@ -4,6 +4,7 @@
 PREFIX="${DESK_DIR:-$HOME/.desk}"
 DESKS="${DESK_DESKS_DIR:-$PREFIX/desks}"
 DESKFILE_NAME=Deskfile
+DESK_SHELL_ARGS="${DESK_SHELL_ARGS:-}"
 
 
 ## Commands
@@ -133,6 +134,9 @@ cmd_go() {
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
+        if [ -n "$DESK_SHELL_ARGS" ]; then
+            set -- "$DESK_SHELL_ARGS" "$@"
+        fi
         DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" exec "${SHELL_EXEC}" "$@"
     fi
 }

--- a/test/run_tests.fish
+++ b/test/run_tests.fish
@@ -18,4 +18,10 @@ set RAN (desk run hello 'say_hello mrfish')
 echo $RAN | grep "Hello mrfish" >/dev/null
 test $status -ne 0; and echo "Desk run with 'hello' failed"; and exit 1
 
+set RAN (env DESK_SHELL_ARGS=-l desk run hello 'status --is-login && echo YES || echo NO')
+echo $RAN | grep "YES" >/dev/null
+test $status -ne 0; and echo "Desk run with DESK_SHELL_ARGS failed"; and exit 1
+
+echo "tests pass."
+
 exit 0

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -143,6 +143,10 @@ RAN=$(desk run hello echo ahoy matey)
 echo "$RAN" | grep 'ahoy matey' >/dev/null
 ensure $? "Run in desk 'hello' didn't work with argument vector"
 
+RAN=$(DESK_SHELL_ARGS="-l" desk run hello shopt)
+echo "$RAN" | grep 'login_shell.*on' >/dev/null
+ensure $? "Run in desk 'hello' didn't work with DESK_SHELL_ARGS"
+
 ## `desk go`
 
 RAN=$(desk go example-project/Deskfile -c 'desk ; exit')


### PR DESCRIPTION
This allows users to pass arguments to the shell invocation.

Example: Using "DESK_SHELL_ARGS=-l" to start the desk shell as login
shell.